### PR TITLE
Release 1.2.3

### DIFF
--- a/Example/Tests/Mock.swift
+++ b/Example/Tests/Mock.swift
@@ -55,3 +55,15 @@ extension String {
         return randomString
     }
 }
+
+class SpyObserver<Result> {
+    var invokedTime: Int = 0
+    let invoked: (Result) -> Void
+    init(_ invoked: @escaping (Result) -> Void) {
+        self.invoked = invoked
+    }
+    func invoke(with result: Result) {
+        invokedTime += 1
+        invoked(result)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -91,16 +91,17 @@ Ness.default
     .executeAndForget()
 ```
 
-you can do something very readable like this by separating all closure using function:
+you can do something very readable like this by using observer method call:
 
 ```swift
 Ness.default
     .httpRequest(.get, withUrl: "https://myurl.com")
     .prepareDataRequest()
     .then(
-        run: updateTheViewWithData,
-        whenFailed: showFailureAlert,
-        finally: removeLoading
+        observing: self,
+        call: Some.updateTheView(withResult:),
+        whenFailedCall: Some.showFailureAlert,
+        finallyCall: Some.removeLoading
     )
 ```
 
@@ -269,7 +270,24 @@ Ness.default
     )
 ```
 
-With custom dispatcher which will be the thread where completion run:
+You could do something similar with observer and its method reference. It will be weak refer to observer and do nothing if the observer is already deinitialised by ARC:
+```swift
+Ness.default
+    .httpRequest(.get, withUrl: "https://myurl.com")
+    ..
+    ..
+    .prepareDataRequest()
+    .then(
+        observing: self,
+        call: Some.updateTheView(withResult:),
+        whenFailedCall: Some.showFailureAlert,
+        finallyCall: Some.removeLoading
+    )
+```
+
+All of the complement method (whenFailedCall, finallyCall) are optional. Use it when you need it.
+
+You could give custom dispatcher which will be the thread where completion run:
 
 ```swift
 Ness.default

--- a/iONess.podspec
+++ b/iONess.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'iONess'
-  s.version          = '1.2.2'
+  s.version          = '1.2.3'
   s.summary          = 'iOS Network Session'
 
 # This description is used to generate tags and improve search results.

--- a/iONess/Classes/DropableAndResumable/DropableURLRequest.swift
+++ b/iONess/Classes/DropableAndResumable/DropableURLRequest.swift
@@ -77,7 +77,8 @@ extension BaseDropableURLRequest {
         ) { retryStatus in
             switch retryStatus {
             case .retryAfter(let delay):
-                DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: onRetry)
+                let dispatcher: DispatchQueue = OperationQueue.current?.underlyingQueue ?? .main
+                dispatcher.asyncAfter(deadline: .now() + delay, execute: onRetry)
             case .retry:
                 onRetry()
             case .noRetry:


### PR DESCRIPTION
- Added observer method call
```swift
request.then(
    observing: someScreen, 
    call: SomeScreen.methodName,
    whenFailedCall: SomeScreen.failedMethodName,
    finallyCall: SomeScreen.finallyMethodName
)
```
- Change retry delaying dispatcher to be run on the current dispatcher if possible
- Integration test for observer method call